### PR TITLE
chore(tauri-android): bump app version to 4.2.0

### DIFF
--- a/apps/tauri-android/src-tauri/tauri.conf.json
+++ b/apps/tauri-android/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DG-Agent",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "identifier": "ai.nullai.dgagent",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
安卓 app 版本号 bump 到 4.2.0,用于 v4.2.0 的 APK 构建。