### PR TITLE
feat(web): 波形与场景支持从 DG-Market 社区市场导入

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -230,6 +230,7 @@ export function App({ servicesOverrides }: AppProps = {}) {
     editingWaveform,
     setEditingWaveform,
     importWaveformFiles,
+    importWaveformFromMarket,
     removeWaveform,
     openWaveformEditor,
     saveWaveformEdits,
@@ -756,6 +757,7 @@ export function App({ servicesOverrides }: AppProps = {}) {
                 waveforms={waveforms}
                 customWaveforms={customWaveforms}
                 onImportWaveforms={(files) => void importWaveformFiles(files)}
+                onImportWaveformFromMarket={(waveform) => void importWaveformFromMarket(waveform)}
                 onRemoveWaveform={(id) => void removeWaveform(id)}
                 onEditWaveform={openWaveformEditor}
                 bridgeLogs={bridgeLogs}

--- a/apps/web/src/components/MarketImportDialog.tsx
+++ b/apps/web/src/components/MarketImportDialog.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Download, Search } from 'lucide-react';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  fetchMarketItems,
+  markMarketDownloaded,
+  type MarketItem,
+  type MarketItemType,
+} from '@/lib/market';
+
+interface MarketImportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  type: MarketItemType;
+  // 返回 true 表示导入成功，对话框据此给出反馈。
+  onImport: (item: MarketItem) => Promise<void> | void;
+}
+
+export function MarketImportDialog({
+  open,
+  onOpenChange,
+  type,
+  onImport,
+}: MarketImportDialogProps) {
+  const [items, setItems] = useState<MarketItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [importedIds, setImportedIds] = useState<Set<string>>(new Set());
+
+  const load = useCallback(
+    async (q: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await fetchMarketItems({ type, q: q.trim() || undefined, sort: 'popular' });
+        setItems(result);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        setItems([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [type],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const id = window.setTimeout(() => void load(query), query ? 300 : 0);
+    return () => window.clearTimeout(id);
+  }, [open, query, load]);
+
+  async function handleImport(item: MarketItem) {
+    await onImport(item);
+    void markMarketDownloaded(item.id);
+    setImportedIds((prev) => new Set(prev).add(item.id));
+  }
+
+  const label = type === 'waveform' ? '波形' : '场景';
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        overlayClassName="bg-black/18 backdrop-blur-[2px]"
+        className="max-w-[680px] overflow-hidden p-0"
+      >
+        <div className="panel-header">
+          <div className="min-w-0 flex-1">
+            <DialogTitle className="text-[1.1rem] tracking-[-0.03em]">
+              从市场导入{label}
+            </DialogTitle>
+            <DialogDescription className="mt-1">
+              浏览社区上传的{label}，一键加入本地库
+            </DialogDescription>
+          </div>
+        </div>
+
+        <div className="px-5 pb-5">
+          <div className="relative mb-3">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-faint)]" />
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={`搜索${label}名称 / 标签`}
+              className="pl-9"
+            />
+          </div>
+
+          <div className="max-h-[52vh] space-y-1.5 overflow-y-auto">
+            {loading && (
+              <div className="py-8 text-center text-sm text-[var(--text-faint)]">加载中…</div>
+            )}
+            {error && (
+              <div className="py-8 text-center text-sm text-[var(--danger)]">
+                {error}
+                <div className="mt-1 text-[12px] text-[var(--text-faint)]">
+                  请确认已部署 DG-Market 并配置了市场地址
+                </div>
+              </div>
+            )}
+            {!loading && !error && items.length === 0 && (
+              <div className="py-8 text-center text-sm text-[var(--text-faint)]">
+                市场里还没有{label}
+              </div>
+            )}
+            {!loading &&
+              !error &&
+              items.map((item) => {
+                const imported = importedIds.has(item.id);
+                return (
+                  <div
+                    key={item.id}
+                    className="group flex items-center gap-3 rounded-[10px] px-3 py-2.5 hover:bg-[var(--bg-soft)]"
+                  >
+                    <span className="shrink-0 text-lg">
+                      {type === 'scenario' ? item.icon || '🎭' : '〰️'}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm text-[var(--text)]">{item.name}</div>
+                      <div className="mt-0.5 truncate text-[12px] text-[var(--text-faint)]">
+                        {item.author ? `@${item.author}` : '匿名'} · ↓ {item.downloads}
+                        {item.description ? ` · ${item.description}` : ''}
+                      </div>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant={imported ? 'ghost' : 'secondary'}
+                      className="shrink-0 gap-1"
+                      disabled={imported}
+                      onClick={() => void handleImport(item)}
+                    >
+                      <Download className="h-3.5 w-3.5" />
+                      {imported ? '已导入' : '导入'}
+                    </Button>
+                  </div>
+                );
+              })}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/PresetSelector.tsx
+++ b/apps/web/src/components/PresetSelector.tsx
@@ -1,11 +1,13 @@
 import { useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import { BUILTIN_PROMPT_PRESETS, type SavedPromptPreset } from '@dg-agent/runtime';
 import type { BrowserAppSettings } from '@dg-agent/storage-browser';
-import { Check, EyeOff, FileText, Pencil, Plus, RotateCcw, Trash2 } from 'lucide-react';
+import { Check, EyeOff, FileText, Pencil, Plus, RotateCcw, Store, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
+import type { MarketItem, MarketScenarioContent } from '@/lib/market';
+import { MarketImportDialog } from './MarketImportDialog.js';
 
 const DEFAULT_CUSTOM_ICON = '📝';
 
@@ -98,6 +100,7 @@ export function PresetSelector({
   const [newName, setNewName] = useState('');
   const [newIcon, setNewIcon] = useState(DEFAULT_CUSTOM_ICON);
   const [newPrompt, setNewPrompt] = useState('');
+  const [marketOpen, setMarketOpen] = useState(false);
 
   const hiddenIds = settingsDraft.hiddenBuiltinPresetIds ?? [];
   const visibleBuiltins = BUILTIN_PROMPT_PRESETS.filter((p) => !hiddenIds.includes(p.id));
@@ -169,6 +172,24 @@ export function PresetSelector({
     setNewName('');
     setNewIcon(DEFAULT_CUSTOM_ICON);
     setNewPrompt('');
+  }
+
+  function importFromMarket(item: MarketItem) {
+    const id = `market-${item.id}`;
+    const prompt = (item.content as MarketScenarioContent).prompt;
+    setSettingsDraft((current) => {
+      if (current.savedPromptPresets.some((p) => p.id === id)) {
+        return { ...current, promptPresetId: id };
+      }
+      return {
+        ...current,
+        promptPresetId: id,
+        savedPromptPresets: [
+          ...current.savedPromptPresets,
+          { id, name: item.name, icon: item.icon || DEFAULT_CUSTOM_ICON, prompt },
+        ],
+      };
+    });
   }
 
   return (
@@ -372,16 +393,33 @@ export function PresetSelector({
             </div>
           </div>
         ) : (
-          <Button
-            variant="ghost"
-            className="w-full justify-center gap-2 rounded-[10px] border border-dashed border-[var(--surface-border)] text-[var(--text-soft)] hover:border-[var(--accent)] hover:text-[var(--accent)]"
-            onClick={startCreate}
-          >
-            <Plus className="h-4 w-4" />
-            <span className="-mt-[0.1em] text-sm">新建场景</span>
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="ghost"
+              className="flex-1 justify-center gap-2 rounded-[10px] border border-dashed border-[var(--surface-border)] text-[var(--text-soft)] hover:border-[var(--accent)] hover:text-[var(--accent)]"
+              onClick={startCreate}
+            >
+              <Plus className="h-4 w-4" />
+              <span className="-mt-[0.1em] text-sm">新建场景</span>
+            </Button>
+            <Button
+              variant="ghost"
+              className="flex-1 justify-center gap-2 rounded-[10px] border border-dashed border-[var(--surface-border)] text-[var(--text-soft)] hover:border-[var(--accent)] hover:text-[var(--accent)]"
+              onClick={() => setMarketOpen(true)}
+            >
+              <Store className="h-4 w-4" />
+              <span className="-mt-[0.1em] text-sm">从市场导入</span>
+            </Button>
+          </div>
         )}
       </section>
+
+      <MarketImportDialog
+        open={marketOpen}
+        onOpenChange={setMarketOpen}
+        type="scenario"
+        onImport={importFromMarket}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/SettingsDrawer.tsx
+++ b/apps/web/src/components/SettingsDrawer.tsx
@@ -147,6 +147,7 @@ export interface SettingsDrawerProps {
   waveforms: WaveformDefinition[];
   customWaveforms: WaveformDefinition[];
   onImportWaveforms: (files: FileList | null) => void;
+  onImportWaveformFromMarket: (waveform: WaveformDefinition) => void | Promise<void>;
   onRemoveWaveform: (id: string) => void;
   onEditWaveform: (waveform: WaveformDefinition) => void;
   bridgeLogs: BridgeLogEntry[];
@@ -167,6 +168,7 @@ function SettingsTabContent({
   waveforms,
   customWaveforms,
   onImportWaveforms,
+  onImportWaveformFromMarket,
   onRemoveWaveform,
   onEditWaveform,
   bridgeLogs,
@@ -200,6 +202,7 @@ function SettingsTabContent({
           waveforms={waveforms}
           customWaveforms={customWaveforms}
           onImport={(files) => onImportWaveforms(files)}
+          onImportFromMarket={onImportWaveformFromMarket}
           onRemove={(id) => onRemoveWaveform(id)}
           onEdit={onEditWaveform}
         />

--- a/apps/web/src/components/WaveformsPanel.tsx
+++ b/apps/web/src/components/WaveformsPanel.tsx
@@ -1,11 +1,15 @@
+import { useState } from 'react';
 import type { WaveformDefinition } from '@dg-agent/core';
-import { Pencil, Trash2, Upload } from 'lucide-react';
+import { Pencil, Store, Trash2, Upload } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import type { MarketItem, MarketWaveformContent } from '@/lib/market';
+import { MarketImportDialog } from './MarketImportDialog.js';
 
 interface WaveformsPanelProps {
   waveforms: WaveformDefinition[];
   customWaveforms: WaveformDefinition[];
   onImport: (files: FileList | null) => void;
+  onImportFromMarket: (waveform: WaveformDefinition) => void | Promise<void>;
   onRemove: (id: string) => void;
   onEdit: (waveform: WaveformDefinition) => void;
 }
@@ -14,9 +18,22 @@ export function WaveformsPanel({
   waveforms,
   customWaveforms,
   onImport,
+  onImportFromMarket,
   onRemove,
   onEdit,
 }: WaveformsPanelProps) {
+  const [marketOpen, setMarketOpen] = useState(false);
+
+  async function handleMarketImport(item: MarketItem) {
+    const { frames } = item.content as MarketWaveformContent;
+    await onImportFromMarket({
+      id: `market-${item.id}`,
+      name: item.name,
+      description: item.description,
+      frames,
+    });
+  }
+
   return (
     <div className="settings-panel-tab-content">
       <section className="settings-row-card">
@@ -65,18 +82,35 @@ export function WaveformsPanel({
           })}
         </div>
 
-        <label className="!flex flex-col w-full cursor-pointer items-center justify-center gap-2 rounded-[10px] border border-dashed border-[var(--surface-border)] px-4 py-2.5 text-sm text-[var(--text-soft)] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)]">
-          <Upload className="h-4 w-4" />
-          <span>导入波形文件</span>
-          <input
-            type="file"
-            accept=".pulse,.zip"
-            multiple
-            className="hidden"
-            onChange={(event) => onImport(event.target.files)}
-          />
-        </label>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <label className="!flex flex-1 cursor-pointer flex-col items-center justify-center gap-2 rounded-[10px] border border-dashed border-[var(--surface-border)] px-4 py-2.5 text-sm text-[var(--text-soft)] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)]">
+            <Upload className="h-4 w-4" />
+            <span>导入波形文件</span>
+            <input
+              type="file"
+              accept=".pulse,.zip"
+              multiple
+              className="hidden"
+              onChange={(event) => onImport(event.target.files)}
+            />
+          </label>
+          <button
+            type="button"
+            className="flex flex-1 cursor-pointer flex-col items-center justify-center gap-2 rounded-[10px] border border-dashed border-[var(--surface-border)] px-4 py-2.5 text-sm text-[var(--text-soft)] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)]"
+            onClick={() => setMarketOpen(true)}
+          >
+            <Store className="h-4 w-4" />
+            <span>从市场导入</span>
+          </button>
+        </div>
       </section>
+
+      <MarketImportDialog
+        open={marketOpen}
+        onOpenChange={setMarketOpen}
+        type="waveform"
+        onImport={handleMarketImport}
+      />
     </div>
   );
 }

--- a/apps/web/src/hooks/use-waveform-manager.ts
+++ b/apps/web/src/hooks/use-waveform-manager.ts
@@ -51,6 +51,20 @@ export function useWaveformManager(options: UseWaveformManagerOptions) {
     [refreshWaveforms, setErrorMessage, setStatusMessage, waveformLibrary],
   );
 
+  const importWaveformFromMarket = useCallback(
+    async (waveform: WaveformDefinition): Promise<void> => {
+      try {
+        setErrorMessage(null);
+        await waveformLibrary.saveCustom(waveform);
+        await refreshWaveforms();
+        setStatusMessage(`已从市场导入「${waveform.name}」`);
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : String(error));
+      }
+    },
+    [refreshWaveforms, setErrorMessage, setStatusMessage, waveformLibrary],
+  );
+
   const removeWaveform = useCallback(
     async (id: string): Promise<void> => {
       try {
@@ -98,6 +112,7 @@ export function useWaveformManager(options: UseWaveformManagerOptions) {
     setEditingWaveform,
     refreshWaveforms,
     importWaveformFiles,
+    importWaveformFromMarket,
     removeWaveform,
     openWaveformEditor,
     saveWaveformEdits,

--- a/apps/web/src/lib/market.ts
+++ b/apps/web/src/lib/market.ts
@@ -1,0 +1,56 @@
+// DG-Market 社区市场客户端：拉取他人上传的波形 / 场景，供「从市场导入」使用。
+// 部署 DG-Market 后，把下面的 VITE_MARKET_BASE_URL 设为你的 Worker 地址，
+// 或直接改这里的兜底常量。
+
+const FALLBACK_BASE_URL = 'https://dg-market.workers.dev';
+
+export const MARKET_BASE_URL: string =
+  (import.meta.env.VITE_MARKET_BASE_URL as string | undefined)?.replace(/\/$/, '') ??
+  FALLBACK_BASE_URL;
+
+export type MarketItemType = 'waveform' | 'scenario';
+
+export interface MarketWaveformContent {
+  frames: [number, number][];
+  pulse?: string;
+}
+
+export interface MarketScenarioContent {
+  prompt: string;
+}
+
+export interface MarketItem {
+  id: string;
+  type: MarketItemType;
+  name: string;
+  description?: string;
+  author?: string;
+  icon?: string;
+  tags: string[];
+  content: MarketWaveformContent | MarketScenarioContent;
+  downloads: number;
+  createdAt: number;
+}
+
+export interface FetchMarketParams {
+  type: MarketItemType;
+  q?: string;
+  sort?: 'new' | 'popular';
+  limit?: number;
+}
+
+export async function fetchMarketItems(params: FetchMarketParams): Promise<MarketItem[]> {
+  const search = new URLSearchParams({ type: params.type });
+  if (params.q) search.set('q', params.q);
+  if (params.sort) search.set('sort', params.sort);
+  search.set('limit', String(params.limit ?? 50));
+
+  const res = await fetch(`${MARKET_BASE_URL}/api/items?${search.toString()}`);
+  if (!res.ok) throw new Error(`市场请求失败 (${res.status})`);
+  const data = (await res.json()) as { items?: MarketItem[] };
+  return data.items ?? [];
+}
+
+export async function markMarketDownloaded(id: string): Promise<void> {
+  await fetch(`${MARKET_BASE_URL}/api/items/${id}/download`, { method: 'POST' }).catch(() => {});
+}

--- a/apps/web/src/lib/market.ts
+++ b/apps/web/src/lib/market.ts
@@ -2,7 +2,7 @@
 // 部署 DG-Market 后，把下面的 VITE_MARKET_BASE_URL 设为你的 Worker 地址，
 // 或直接改这里的兜底常量。
 
-const FALLBACK_BASE_URL = 'https://dg-market.workers.dev';
+const FALLBACK_BASE_URL = 'https://dg-market.0xnullai.workers.dev';
 
 export const MARKET_BASE_URL: string =
   (import.meta.env.VITE_MARKET_BASE_URL as string | undefined)?.replace(/\/$/, '') ??


### PR DESCRIPTION
## Summary
新增「从市场导入」入口：波形库与自定义场景面板均可直接拉取 [DG-Market](https://github.com/0xNullAI/DG-Market) 社区上传的内容并一键加入本地库。市场地址通过 `VITE_MARKET_BASE_URL` 配置，默认指向 https://dg-market.0xnullai.workers.dev 。

- 新增 `apps/web/src/lib/market.ts`：市场客户端
- 新增 `MarketImportDialog`：波形/场景复用的导入对话框
- `use-waveform-manager` 增加 `importWaveformFromMarket`，透传至 `WaveformsPanel`
- `PresetSelector` 增加场景导入入口

## Test plan
- [x] npm run typecheck
- [x] npm run test （92 passed）
- [x] npm run lint （零警告）
- [x] npm run build
- [ ] Smoke test in browser