### PR TITLE
Release 5.0.1：修复 worker eslint globals（CI 转绿）

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -83,6 +83,29 @@ export default tseslint.config(
     },
   },
   {
+    // Cloudflare Worker relays（llm-proxy / speech-proxy）：运行在 Workers 运行时，
+    // 使用 Response/fetch/URL/WebSocketPair 等全局，需声明 worker 环境。
+    files: ['workers/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.serviceworker,
+        WebSocketPair: 'readonly',
+      },
+    },
+    rules: {
+      'no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
+  {
     files: ['vite.config.ts', 'apps/*/vite.config.ts'],
     languageOptions: {
       ecmaVersion: 'latest',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dg-agent",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "type": "module",
   "packageManager": "npm@11.6.2",


### PR DESCRIPTION
## Summary
`workers/llm-proxy` 与 `workers/speech-proxy` 是 Cloudflare Worker（.js），使用 `Response`/`fetch`/`URL`/`WebSocketPair` 等运行时全局，但 eslint 配置缺少 worker 环境声明，导致 13 个 `no-undef` 错误、main CI 持续失败。本 PR 给 `workers/**` 加 serviceworker globals 块修复，CI 转绿。

## Test plan
- [x] npm run lint（零错误）
- [x] 版本 bump 5.0.0 → 5.0.1