### PR TITLE
feat(runtime): System Prompt 静态化，Tool Result 作为上下文传入

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -48,7 +48,7 @@ import {
   getSessionTitle,
   isBluetoothChooserCancelledError,
 } from './utils/ui-formatters.js';
-import { buildTraceFeed } from './utils/trace-feed.js';
+import { buildTraceFeed, mergeTraceFeed } from './utils/trace-feed.js';
 import {
   parseSessionsFromJson,
   serializeSessionFile,
@@ -185,10 +185,7 @@ export function App({ servicesOverrides }: AppProps = {}) {
     ...serviceInitWarnings,
   ];
   const historicalTraceFeed = buildTraceFeed(sessionTrace);
-  const traceFeed =
-    liveTraceItems.length > 0
-      ? [...historicalTraceFeed, ...liveTraceItems].sort((a, b) => a.createdAt - b.createdAt)
-      : historicalTraceFeed;
+  const traceFeed = mergeTraceFeed(historicalTraceFeed, liveTraceItems);
 
   const { visibleErrorItems, visibleWarnings, visibleEventToasts } = useToastManager({
     errorMessage,

--- a/apps/web/src/__tests__/build-browser-instructions.test.ts
+++ b/apps/web/src/__tests__/build-browser-instructions.test.ts
@@ -1,12 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  createEmptyDeviceState,
-  type ActionContext,
-  type ConversationMessage,
-  type SessionSnapshot,
-  type SourceType,
-} from '@dg-agent/core';
-import type { TurnToolCallSummary } from '@dg-agent/runtime';
+import type { ActionContext, SourceType } from '@dg-agent/core';
 import {
   createBuildBrowserInstructions,
   type BrowserInstructionSettings,
@@ -16,82 +9,48 @@ function makeSettings(overrides?: Partial<BrowserInstructionSettings>): BrowserI
   return {
     promptPresetId: 'gentle',
     savedPromptPresets: [],
-    maxStrengthA: 100,
-    maxStrengthB: 100,
     ...overrides,
   };
 }
 
-function makeInput(overrides?: {
-  isFirstIteration?: boolean;
-  sourceType?: SourceType;
-  turnToolCalls?: TurnToolCallSummary[];
-  deviceState?: ReturnType<typeof createEmptyDeviceState>;
-}) {
-  const deviceState = overrides?.deviceState ?? { ...createEmptyDeviceState(), connected: true };
-  const session: SessionSnapshot = {
-    id: 'test',
-    createdAt: 0,
-    updatedAt: 0,
-    messages: [] as ConversationMessage[],
-    deviceState,
-  };
+function makeInput(sourceType: SourceType = 'web') {
   const context: ActionContext = {
     sessionId: 'test',
-    sourceType: overrides?.sourceType ?? 'web',
+    sourceType,
     traceId: 'trace-test',
   };
-  return {
-    session,
-    context,
-    isFirstIteration: overrides?.isFirstIteration ?? true,
-    turnToolCalls: overrides?.turnToolCalls ?? [],
-  };
+  return { context };
 }
 
 describe('createBuildBrowserInstructions', () => {
-  it('first iteration includes 本回合策略 block', () => {
+  it('returns the same static prompt regardless of iteration', () => {
     const build = createBuildBrowserInstructions(makeSettings());
-    const output = build(makeInput({ isFirstIteration: true }));
-    expect(output).toContain('[本回合策略');
-    expect(output).not.toContain('[后续迭代提醒]');
-  });
-
-  it('subsequent iteration includes 后续迭代提醒 block, not 本回合策略', () => {
-    const build = createBuildBrowserInstructions(makeSettings());
-    const output = build(makeInput({ isFirstIteration: false }));
-    expect(output).toContain('[后续迭代提醒]');
-    expect(output).not.toContain('[本回合策略');
+    const first = build(makeInput());
+    const second = build(makeInput());
+    expect(first).toBe(second);
+    expect(first).not.toContain('[当前设备状态]');
+    expect(first).not.toContain('[本回合已调用工具]');
+    expect(first).not.toContain('[本回合策略');
+    expect(first).not.toContain('[后续迭代提醒]');
   });
 
   it('system source type includes 系统触发说明 block', () => {
     const build = createBuildBrowserInstructions(makeSettings());
-    const output = build(makeInput({ sourceType: 'system' }));
+    const output = build(makeInput('system'));
     expect(output).toContain('[系统触发说明]');
   });
 
   it('web source type does not include 系统触发说明 block', () => {
     const build = createBuildBrowserInstructions(makeSettings());
-    const output = build(makeInput({ sourceType: 'web' }));
+    const output = build(makeInput('web'));
     expect(output).not.toContain('[系统触发说明]');
   });
 
-  it('empty tool calls includes (无) and no-pretend warning', () => {
+  it('documents get_runtime_context instead of embedding live device state', () => {
     const build = createBuildBrowserInstructions(makeSettings());
-    const output = build(makeInput({ turnToolCalls: [] }));
-    expect(output).toContain('(无)');
-    expect(output).toContain('没有真正执行过');
-  });
-
-  it('non-empty tool calls shows numbered list and verification prompt', () => {
-    const build = createBuildBrowserInstructions(makeSettings());
-    const output = build(
-      makeInput({
-        turnToolCalls: [{ name: 'adjust_strength', argsJson: '{"channel":"A","delta":5}' }],
-      }),
-    );
-    expect(output).toContain('1. adjust_strength(');
-    expect(output).toContain('声称已经完成的动作');
+    const output = build(makeInput());
+    expect(output).toContain('[运行上下文工具]');
+    expect(output).toContain('get_runtime_context');
   });
 
   it('always includes 剧情与设备的映射 block regardless of preset', () => {
@@ -110,21 +69,5 @@ describe('createBuildBrowserInstructions', () => {
     const output = build(makeInput());
     expect(output).toContain('custom prompt');
     expect(output).toContain('[剧情与设备的映射]');
-  });
-
-  it('device status block shows effectiveCap = min(limitA, maxStrengthA)', () => {
-    const build = createBuildBrowserInstructions(makeSettings({ maxStrengthA: 80 }));
-    const deviceState = { ...createEmptyDeviceState(), connected: true, limitA: 150 };
-    const output = build(makeInput({ deviceState }));
-    // effectiveCapA = min(150, 80) = 80
-    expect(output).toContain('80');
-  });
-
-  it('device status block shows min of limitA when limitA is smaller', () => {
-    const build = createBuildBrowserInstructions(makeSettings({ maxStrengthA: 200 }));
-    const deviceState = { ...createEmptyDeviceState(), connected: true, limitA: 120 };
-    const output = build(makeInput({ deviceState }));
-    // effectiveCapA = min(120, 200) = 120
-    expect(output).toContain('120');
   });
 });

--- a/apps/web/src/hooks/use-runtime-session-state.ts
+++ b/apps/web/src/hooks/use-runtime-session-state.ts
@@ -134,6 +134,7 @@ export function useRuntimeSessionState(options: UseRuntimeSessionStateOptions) {
     let active = true;
     const sessionId = activeSessionId;
     setReplyBusy(false);
+    setLiveTraceItems([]);
 
     async function syncCurrentSession(): Promise<void> {
       const requestId = ++syncRequestIdRef.current;
@@ -211,11 +212,10 @@ export function useRuntimeSessionState(options: UseRuntimeSessionStateOptions) {
 
       if (shouldRefreshSessionForEvent(event)) {
         if (isActiveSessionEvent) {
-          const isTurnEnd =
-            event.type === 'assistant-message-completed' ||
-            event.type === 'assistant-message-aborted';
           void syncCurrentSession().then(() => {
-            if (isTurnEnd) setLiveTraceItems([]);
+            // Historical trace is authoritative once refreshed; keeping live
+            // items would duplicate device-command-executed pills.
+            setLiveTraceItems([]);
           });
         } else {
           void refreshSavedSessions();

--- a/apps/web/src/utils/trace-feed.ts
+++ b/apps/web/src/utils/trace-feed.ts
@@ -22,6 +22,19 @@ export function buildTraceFeed(entries: RuntimeTraceEntry[]): TraceFeedItem[] {
     .sort((left, right) => left.createdAt - right.createdAt);
 }
 
+export function mergeTraceFeed(
+  historical: TraceFeedItem[],
+  live: TraceFeedItem[],
+): TraceFeedItem[] {
+  if (live.length === 0) {
+    return historical;
+  }
+
+  const seen = new Set(historical.map((item) => item.text));
+  const uniqueLive = live.filter((item) => !seen.has(item.text));
+  return [...historical, ...uniqueLive].sort((left, right) => left.createdAt - right.createdAt);
+}
+
 let liveTraceCounter = 0;
 
 export function buildLiveTraceFeedItemFromEvent(event: RuntimeEvent): TraceFeedItem | null {

--- a/packages/agent-browser/src/build-browser-instructions.ts
+++ b/packages/agent-browser/src/build-browser-instructions.ts
@@ -1,23 +1,15 @@
-import type { ActionContext, SessionSnapshot } from '@dg-agent/core';
+import type { ActionContext } from '@dg-agent/core';
 import { getAnyPromptPresetById, type SavedPromptPreset } from '@dg-agent/runtime';
-import type { TurnToolCallSummary } from '@dg-agent/runtime';
 
 export interface BrowserInstructionSettings {
   promptPresetId: string;
   savedPromptPresets: SavedPromptPreset[];
-  maxStrengthA: number;
-  maxStrengthB: number;
 }
 
 const INSTRUCTION_SEPARATOR = '\n\n──────────────────────────\n';
 
 export function createBuildBrowserInstructions(settings: BrowserInstructionSettings) {
-  return (input: {
-    session: SessionSnapshot;
-    context: ActionContext;
-    isFirstIteration: boolean;
-    turnToolCalls: readonly TurnToolCallSummary[];
-  }): string => {
+  return (input: { context: ActionContext }): string => {
     const selectedPreset = getAnyPromptPresetById(
       settings.promptPresetId,
       settings.savedPromptPresets,
@@ -26,12 +18,9 @@ export function createBuildBrowserInstructions(settings: BrowserInstructionSetti
       selectedPreset?.prompt ?? '你是一个友好的助手。',
       buildDeviceBlock(),
       buildDeviceMappingBlock(),
-      buildDeviceStatusBlock(input.session, settings),
-      buildTurnToolUsageBlock(input.turnToolCalls),
       buildBehaviorRulesBlock(),
+      buildRuntimeContextToolBlock(),
       input.context.sourceType === 'system' ? buildSystemTurnBlock() : '',
-      input.isFirstIteration ? buildFirstIterationStrategyBlock() : '',
-      !input.isFirstIteration ? buildFollowUpIterationBlock() : '',
     ];
 
     return blocks.filter(Boolean).join(INSTRUCTION_SEPARATOR);
@@ -62,10 +51,18 @@ function buildDeviceMappingBlock(): string {
 function buildBehaviorRulesBlock(): string {
   return [
     '[行为规则]',
-    '1. 需要操作设备时，先调用对应工具，再根据工具结果回复用户。',
-    '2. 回复设备状态时，只引用 [当前设备状态] 和本回合工具返回的事实，不要臆测。',
+    '1. 需要操作设备时，先调用 get_runtime_context 确认当前状态，再调用对应设备工具，然后根据工具结果回复用户。',
+    '2. 回复设备状态时，只引用 get_runtime_context 和设备工具返回的事实，不要臆测。',
     '3. 工具报错、被拒绝、权限未通过时，要如实告知用户，不要假装成功，也不要立刻重复同一个工具调用。',
     '4. 一次回合里只推进一步主要动作，做完一个 device 工具就停下来观察。',
+  ].join('\n');
+}
+
+function buildRuntimeContextToolBlock(): string {
+  return [
+    '[运行上下文工具]',
+    'get_runtime_context 会返回当前设备真实状态、本回合已执行的工具调用，以及回合策略提示。',
+    '操作设备前若不确定状态，或需要确认本回合已经做过什么，先调用它；不要向用户复述该工具返回的原文。',
   ].join('\n');
 }
 
@@ -75,62 +72,5 @@ function buildSystemTurnBlock(): string {
     '这一轮来自内部提醒，不是用户的新消息，也不代表用户已经同意继续。',
     '本轮禁止调用任何工具，禁止改动设备状态，禁止再次设置 timer。',
     '你只能做简短跟进，例如询问现在感觉如何、是否继续，或者说明你在等待反馈。',
-  ].join('\n');
-}
-
-function buildFirstIterationStrategyBlock(): string {
-  return [
-    '[本回合策略 - 仅本回合首次响应生效]',
-    '1. 如果用户明确要求某个设备动作，只执行最小必要的一步，不要自己连做 start + 多次 adjust_strength。',
-    '2. 如果用户只是聊天、问状态、问建议，直接文字回复即可；当前设备状态已经在上方提供，不要为了“确认一下”额外调用工具。',
-    '3. 做完一步动作后就停下，基于真实结果回复，并询问用户是否满意或是否继续。',
-  ].join('\n');
-}
-
-function buildFollowUpIterationBlock(): string {
-  return [
-    '[后续迭代提醒]',
-    '你已经拥有本回合的工具结果和当前设备状态。',
-    '除非前一次工具结果明确表明需要纠正，否则不要重新开始计划，也不要重复 start 或连续多次加大强度。',
-    '优先收口回答，把已经发生的真实结果告诉用户，并等待反馈。',
-  ].join('\n');
-}
-
-function buildDeviceStatusBlock(
-  session: SessionSnapshot,
-  settings: Pick<BrowserInstructionSettings, 'maxStrengthA' | 'maxStrengthB'>,
-): string {
-  const device = session.deviceState;
-  const effectiveCapA = Math.min(device.limitA, settings.maxStrengthA);
-  const effectiveCapB = Math.min(device.limitB, settings.maxStrengthB);
-  const battery = typeof device.battery === 'number' ? `${device.battery}%` : '未知';
-  const connection = device.connected
-    ? `已连接${device.deviceName ? `（${device.deviceName}）` : ''}`
-    : '未连接';
-
-  return [
-    '[当前设备状态]',
-    `连接：${connection}`,
-    `电量：${battery}`,
-    `A 通道：强度 ${device.strengthA} / 上限 ${effectiveCapA}，波形${device.waveActiveA ? '运行中' : '已停止'}，当前波形 ${device.currentWaveA ?? '-'}`,
-    `B 通道：强度 ${device.strengthB} / 上限 ${effectiveCapB}，波形${device.waveActiveB ? '运行中' : '已停止'}，当前波形 ${device.currentWaveB ?? '-'}`,
-  ].join('\n');
-}
-
-function buildTurnToolUsageBlock(calls: readonly TurnToolCallSummary[]): string {
-  if (calls.length === 0) {
-    return [
-      '[本回合已调用工具]',
-      '(无)',
-      '这表示你本回合还没有真正执行过任何设备动作；不要提前声称“已经帮你调整好了”。',
-    ].join('\n');
-  }
-
-  const lines = calls.map((call, index) => `${index + 1}. ${call.name}(${call.argsJson})`);
-  return [
-    '[本回合已调用工具]',
-    ...lines,
-    '生成回复前请对照这份清单：你声称已经完成的动作，必须能在上面找到对应调用。',
-    '如果上面已经做过一次主要动作，下一步通常是解释结果并询问反馈，而不是继续叠加动作。',
   ].join('\n');
 }

--- a/packages/agent-browser/src/create-browser-agent-client.ts
+++ b/packages/agent-browser/src/create-browser-agent-client.ts
@@ -19,7 +19,11 @@ import { OpenAiHttpLlmClient } from '@dg-agent/providers-openai-http';
 import {
   PolicyEngine,
   createDefaultPolicyRules,
-  createDefaultToolRegistryWithDeps,
+  createAgentToolRegistryWithDeps,
+  buildRuntimeContextPayload,
+  collectTurnToolCalls,
+  serializeRuntimeContextPayload,
+  type RuntimeContextSettings,
 } from '@dg-agent/runtime';
 import type { BrowserAppSettings } from '@dg-agent/storage-browser';
 import { createBuildBrowserInstructions } from './build-browser-instructions.js';
@@ -112,7 +116,7 @@ export function createBrowserAgentClient(options: CreateBrowserAgentClientOption
   return createEmbeddedAgentClient({
     device: options.device,
     llm,
-    toolRegistry: createDefaultToolRegistryWithDeps({
+    toolRegistry: createAgentToolRegistryWithDeps({
       waveformLibrary: options.waveformLibrary,
       toolDefinitionHints: {
         maxColdStartStrength: settings.maxColdStartStrength,
@@ -141,9 +145,20 @@ export function createBrowserAgentClient(options: CreateBrowserAgentClientOption
     buildInstructions: createBuildBrowserInstructions({
       promptPresetId: settings.promptPresetId,
       savedPromptPresets: settings.savedPromptPresets,
-      maxStrengthA: settings.maxStrengthA,
-      maxStrengthB: settings.maxStrengthB,
     }),
+    buildRuntimeContext: ({ session, context, turnState, isFirstIteration }) =>
+      serializeRuntimeContextPayload(
+        buildRuntimeContextPayload({
+          session,
+          context,
+          turnToolCalls: collectTurnToolCalls(turnState),
+          isFirstIteration,
+          settings: {
+            maxStrengthA: settings.maxStrengthA,
+            maxStrengthB: settings.maxStrengthB,
+          } satisfies RuntimeContextSettings,
+        }),
+      ),
     toolCallConfig: {
       maxToolIterations: settings.maxToolIterations,
       maxToolCallsPerTurn: settings.maxToolCallsPerTurn,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,11 @@ export interface ActionContext {
   traceId: string;
 }
 
+export interface ToolCallResult {
+  callId: string;
+  output: string;
+}
+
 export interface ConversationMessage {
   id: string;
   role: MessageRole;
@@ -41,6 +46,7 @@ export interface ConversationMessage {
   createdAt: number;
   reasoningContent?: string;
   toolCalls?: ToolCall[];
+  toolResults?: ToolCallResult[];
 }
 
 export interface SessionSnapshot {
@@ -217,7 +223,7 @@ export function createMessage(
   role: MessageRole,
   content: string,
   createdAt = Date.now(),
-  options?: Pick<ConversationMessage, 'reasoningContent' | 'toolCalls'>,
+  options?: Pick<ConversationMessage, 'reasoningContent' | 'toolCalls' | 'toolResults'>,
 ): ConversationMessage {
   return {
     id: `${createdAt}-${Math.random().toString(36).slice(2, 8)}`,
@@ -226,6 +232,7 @@ export function createMessage(
     createdAt,
     reasoningContent: options?.reasoningContent,
     toolCalls: options?.toolCalls ? structuredClone(options.toolCalls) : undefined,
+    toolResults: options?.toolResults ? structuredClone(options.toolResults) : undefined,
   };
 }
 

--- a/packages/runtime/src/agent-runtime.ts
+++ b/packages/runtime/src/agent-runtime.ts
@@ -18,6 +18,7 @@ import {
   type ModelContextStrategy,
   type RuntimeTraceEntry,
   type SessionSnapshot,
+  type ToolCall,
 } from '@dg-agent/core';
 import { createDefaultPolicyRules } from './default-policies.js';
 import { DeviceCommandQueue } from './device-command-queue.js';
@@ -38,31 +39,28 @@ import {
   type ToolCallConfig,
   type ToolCallConfigInput,
 } from './tool-call-config.js';
-import {
-  buildConversationItems,
-  collectTurnToolCalls,
-  createTurnState,
-  type TurnState,
-  type TurnToolCallSummary,
-} from './runtime-turn-state.js';
+import { buildConversationItems, createTurnState, type TurnState } from './runtime-turn-state.js';
 import { InMemorySessionTraceStore } from './session-trace.js';
 import {
   normalizeSessionHistory,
   appendAssistantMessage,
+  appendAssistantToolRound,
   appendSkippedToolOutputs,
+  hydrateToolResultsFromTrace,
 } from './session-history.js';
-import { createDefaultToolRegistryWithDeps } from './tool-registry.js';
+import { createAgentToolRegistryWithDeps } from './agent-tool-registry.js';
 import type { ToolRegistry } from './tool-registry.js';
 
 export interface AgentRuntimeOptions {
   device: DeviceClient;
   llm: LlmClient;
   permission: PermissionService;
-  buildInstructions?: (input: {
+  buildInstructions?: (input: { context: ActionContext }) => string;
+  buildRuntimeContext?: (input: {
     session: SessionSnapshot;
     context: ActionContext;
+    turnState: TurnState;
     isFirstIteration: boolean;
-    turnToolCalls: readonly TurnToolCallSummary[];
   }) => string;
   waveformLibrary?: WaveformLibrary;
   sessionStore?: SessionStore;
@@ -116,7 +114,7 @@ export class AgentRuntime {
     this.queue = new DeviceCommandQueue(options.device);
     this.toolRegistry =
       options.toolRegistry ??
-      createDefaultToolRegistryWithDeps({ waveformLibrary: options.waveformLibrary });
+      createAgentToolRegistryWithDeps({ waveformLibrary: options.waveformLibrary });
     this.toolCallConfig = resolveToolCallConfig(options.toolCallConfig);
 
     const policyEngine = options.policyEngine ?? new PolicyEngine(createDefaultPolicyRules());
@@ -129,6 +127,7 @@ export class AgentRuntime {
       policyEngine,
       logger,
       toolCallConfig: this.toolCallConfig,
+      buildRuntimeContext: options.buildRuntimeContext,
       emit: (event) => {
         this.events.emit(event);
       },
@@ -375,10 +374,7 @@ export class AgentRuntime {
 
       const instructions =
         this.options.buildInstructions?.({
-          session,
           context: input.context,
-          isFirstIteration: iteration === 0,
-          turnToolCalls: collectTurnToolCalls(turnState),
         }) ?? '';
       const tools =
         input.context.sourceType === 'system' ? [] : await this.toolRegistry.listDefinitions();
@@ -464,29 +460,12 @@ export class AgentRuntime {
       const iterationHasAssistantState = hasTextOrReasoning || hasToolCalls;
 
       if (iterationHasAssistantState) {
-        if (hasTextOrReasoning) {
-          appendAssistantMessage(
-            session,
-            {
-              content: iterationAssistantContent,
-              reasoningContent: llmResult.reasoningContent,
-              toolCalls: llmResult.toolCalls,
-            },
-            turnStartIndex,
-          );
-        }
         iterationItems.push({
           kind: 'message',
           role: 'assistant',
           content: iterationAssistantContent,
           reasoningContent: llmResult.reasoningContent,
           toolCalls: llmResult.toolCalls,
-        });
-        session.updatedAt = Date.now();
-        await this.saveSessionIfAvailable(session);
-        this.events.emit({
-          type: 'session-updated',
-          sessionId: session.id,
         });
       }
 
@@ -500,6 +479,7 @@ export class AgentRuntime {
           context: input.context,
           turnState,
           abortSignal,
+          llmIteration: iteration,
         });
         const deniedTrigger = getEphemeralDeniedTrigger(toolCall, output);
         if (deniedTrigger) {
@@ -546,6 +526,15 @@ export class AgentRuntime {
         });
       }
 
+      if (hasToolCalls) {
+        await this.persistIterationToolRound(session, turnStartIndex, {
+          content: iterationAssistantContent,
+          reasoningContent: llmResult.reasoningContent,
+          toolCalls,
+          iterationItems,
+        });
+      }
+
       turnState.workingItems.push(...iterationItems);
     }
 
@@ -567,10 +556,7 @@ export class AgentRuntime {
       context: input.context,
       instructions:
         this.options.buildInstructions?.({
-          session,
           context: input.context,
-          isFirstIteration: false,
-          turnToolCalls: collectTurnToolCalls(turnState),
         }) ?? '',
       tools: [],
       conversation: buildConversationItems(
@@ -628,7 +614,9 @@ export class AgentRuntime {
   private async ensureSession(sessionId: string): Promise<SessionSnapshot> {
     const existing = await this.sessions.get(sessionId);
     if (existing) {
-      if (normalizeSessionHistory(existing)) {
+      const normalized = normalizeSessionHistory(existing);
+      const hydrated = await this.hydrateSessionToolResults(existing);
+      if (normalized || hydrated) {
         await this.saveSessionIfAvailable(existing);
       }
       return existing;
@@ -645,6 +633,55 @@ export class AgentRuntime {
 
     await this.saveSessionIfAvailable(created);
     return created;
+  }
+
+  private async hydrateSessionToolResults(session: SessionSnapshot): Promise<boolean> {
+    const trace = await this.traces.list(session.id);
+    return hydrateToolResultsFromTrace(session, trace);
+  }
+
+  private async persistIterationToolRound(
+    session: SessionSnapshot,
+    turnStartIndex: number,
+    input: {
+      content: string;
+      reasoningContent?: string;
+      toolCalls: ToolCall[];
+      iterationItems: LlmConversationItem[];
+    },
+  ): Promise<void> {
+    if (input.toolCalls.length === 0) {
+      return;
+    }
+
+    const toolResults = input.iterationItems.flatMap((item) =>
+      item.kind === 'function_call_output' ? [{ callId: item.callId, output: item.output }] : [],
+    );
+    const executedToolCalls = input.toolCalls.filter((toolCall) =>
+      toolResults.some((result) => result.callId === toolCall.id),
+    );
+    if (executedToolCalls.length === 0) {
+      return;
+    }
+
+    appendAssistantToolRound(
+      session,
+      {
+        content: input.content,
+        reasoningContent: input.reasoningContent,
+        toolCalls: executedToolCalls,
+        toolResults: toolResults.filter((result) =>
+          executedToolCalls.some((toolCall) => toolCall.id === result.callId),
+        ),
+      },
+      turnStartIndex,
+    );
+    session.updatedAt = Date.now();
+    await this.saveSessionIfAvailable(session);
+    this.events.emit({
+      type: 'session-updated',
+      sessionId: session.id,
+    });
   }
 
   private enqueueSystemWork(sessionId: string, work: QueuedSystemWork): void {

--- a/packages/runtime/src/agent-tool-registry.ts
+++ b/packages/runtime/src/agent-tool-registry.ts
@@ -1,0 +1,26 @@
+import {
+  createDefaultToolRegistry,
+  type DefaultToolRegistryDeps,
+  type ToolRegistry,
+} from './tool-registry.js';
+import {
+  getRuntimeContextToolDefinition,
+  RUNTIME_CONTEXT_TOOL_NAME,
+} from './runtime-context-tool.js';
+
+export function createAgentToolRegistry(deps: DefaultToolRegistryDeps = {}): ToolRegistry {
+  const registry = createDefaultToolRegistry(deps);
+  registry.register({
+    name: RUNTIME_CONTEXT_TOOL_NAME,
+    displayName: '读取运行上下文',
+    definition: getRuntimeContextToolDefinition(),
+    toExecutionPlan() {
+      // RuntimeToolExecutor handles this tool directly; the registry entry exists
+      // so the model can see and call it.
+      return { type: 'inline', output: '{}' };
+    },
+  });
+  return registry;
+}
+
+export { createAgentToolRegistry as createAgentToolRegistryWithDeps };

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,10 +1,13 @@
 export * from './agent-runtime.js';
+export * from './agent-tool-registry.js';
 export * from './default-policies.js';
 export * from './device-command-queue.js';
 export * from './event-bus.js';
 export * from './in-memory-session-store.js';
 export * from './policy-engine.js';
 export * from './prompts/index.js';
+export * from './runtime-context-tool.js';
 export * from './session-trace.js';
 export * from './tool-call-config.js';
 export * from './tool-registry.js';
+export { collectTurnToolCalls } from './runtime-turn-state.js';

--- a/packages/runtime/src/runtime-context-tool.test.ts
+++ b/packages/runtime/src/runtime-context-tool.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { createEmptyDeviceState } from '@dg-agent/core';
+import { buildRuntimeContextPayload } from './runtime-context-tool.js';
+
+describe('buildRuntimeContextPayload', () => {
+  it('includes device caps and turn tool calls', () => {
+    const payload = buildRuntimeContextPayload({
+      session: {
+        id: 's1',
+        createdAt: 0,
+        updatedAt: 0,
+        messages: [],
+        deviceState: {
+          ...createEmptyDeviceState(),
+          connected: true,
+          limitA: 150,
+          strengthA: 12,
+          waveActiveA: true,
+          currentWaveA: 'pulse_mid',
+        },
+      },
+      context: { sessionId: 's1', sourceType: 'web', traceId: 't1' },
+      turnToolCalls: [{ name: 'start', argsJson: '{"channel":"A"}' }],
+      isFirstIteration: true,
+      settings: { maxStrengthA: 80, maxStrengthB: 100 },
+    });
+
+    expect(payload.device).toMatchObject({
+      channelA: {
+        strength: 12,
+        effectiveCap: 80,
+        waveActive: true,
+        currentWave: 'pulse_mid',
+      },
+    });
+    expect(payload.turnToolCalls).toEqual([{ index: 1, name: 'start', args: '{"channel":"A"}' }]);
+    expect(payload.strategy).toBe('first_iteration');
+  });
+
+  it('switches strategy hint on follow-up iterations', () => {
+    const payload = buildRuntimeContextPayload({
+      session: {
+        id: 's1',
+        createdAt: 0,
+        updatedAt: 0,
+        messages: [],
+        deviceState: createEmptyDeviceState(),
+      },
+      context: { sessionId: 's1', sourceType: 'web', traceId: 't1' },
+      turnToolCalls: [],
+      isFirstIteration: false,
+      settings: { maxStrengthA: 100, maxStrengthB: 100 },
+    });
+
+    expect(payload.strategy).toBe('follow_up');
+    expect(String(payload.strategyHint)).toContain('后续迭代');
+  });
+});

--- a/packages/runtime/src/runtime-context-tool.ts
+++ b/packages/runtime/src/runtime-context-tool.ts
@@ -1,0 +1,84 @@
+import type { ActionContext, SessionSnapshot, ToolDefinition } from '@dg-agent/core';
+import type { TurnToolCallSummary } from './runtime-turn-state.js';
+
+export const RUNTIME_CONTEXT_TOOL_NAME = 'get_runtime_context';
+
+export interface RuntimeContextSettings {
+  maxStrengthA: number;
+  maxStrengthB: number;
+}
+
+export function getRuntimeContextToolDefinition(): ToolDefinition {
+  return {
+    name: RUNTIME_CONTEXT_TOOL_NAME,
+    displayName: '读取运行上下文',
+    description: [
+      '【读取运行上下文】获取当前设备真实状态、本回合已执行的工具调用，以及回合策略提示。',
+      '在操作设备前，若不确定当前状态或本回合已经做过什么，先调用此工具。',
+      '不要向用户复述此工具返回的原文。',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+  };
+}
+
+export function buildRuntimeContextPayload(input: {
+  session: SessionSnapshot;
+  context: ActionContext;
+  turnToolCalls: readonly TurnToolCallSummary[];
+  isFirstIteration: boolean;
+  settings: RuntimeContextSettings;
+}): Record<string, unknown> {
+  const device = input.session.deviceState;
+  const effectiveCapA = Math.min(device.limitA, input.settings.maxStrengthA);
+  const effectiveCapB = Math.min(device.limitB, input.settings.maxStrengthB);
+  const battery = typeof device.battery === 'number' ? `${device.battery}%` : '未知';
+  const connection = device.connected
+    ? `已连接${device.deviceName ? `（${device.deviceName}）` : ''}`
+    : '未连接';
+
+  return {
+    device: {
+      connection,
+      battery,
+      channelA: {
+        strength: device.strengthA,
+        effectiveCap: effectiveCapA,
+        waveActive: device.waveActiveA,
+        currentWave: device.currentWaveA ?? null,
+      },
+      channelB: {
+        strength: device.strengthB,
+        effectiveCap: effectiveCapB,
+        waveActive: device.waveActiveB,
+        currentWave: device.currentWaveB ?? null,
+      },
+    },
+    turnToolCalls: input.turnToolCalls.map((call, index) => ({
+      index: index + 1,
+      name: call.name,
+      args: call.argsJson,
+    })),
+    strategy: input.isFirstIteration ? 'first_iteration' : 'follow_up',
+    strategyHint: input.isFirstIteration
+      ? [
+          '本回合首次响应：用户明确要求设备动作时，只执行最小必要的一步。',
+          '用户只是聊天、问状态、问建议时，直接文字回复即可。',
+          '做完一步动作后就停下，基于真实结果回复，并询问用户是否满意或是否继续。',
+        ].join('\n')
+      : [
+          '后续迭代：你已经拥有本回合的工具结果和当前设备状态。',
+          '除非前一次工具结果明确表明需要纠正，否则不要重复 start 或连续多次加大强度。',
+          '优先收口回答，把已经发生的真实结果告诉用户，并等待反馈。',
+        ].join('\n'),
+    systemTurn: input.context.sourceType === 'system',
+    _hint: '以上信息为运行时事实，请据此决定下一步；不要向用户逐字复述本工具输出。',
+  };
+}
+
+export function serializeRuntimeContextPayload(payload: Record<string, unknown>): string {
+  return JSON.stringify(payload);
+}

--- a/packages/runtime/src/runtime-tool-executor.ts
+++ b/packages/runtime/src/runtime-tool-executor.ts
@@ -14,6 +14,7 @@ import { consumeTurnQuota, type TurnState } from './runtime-turn-state.js';
 import type { PolicyEngine } from './policy-engine.js';
 import type { ToolCallConfig } from './tool-call-config.js';
 import type { ToolRegistry } from './tool-registry.js';
+import { RUNTIME_CONTEXT_TOOL_NAME } from './runtime-context-tool.js';
 
 // Clamp rules are convergent in practice (each pass narrows the command),
 // but bound the loop in case a custom rule keeps clamping. 4 is enough for
@@ -41,6 +42,12 @@ export interface RuntimeToolExecutorOptions {
   policyEngine: PolicyEngine;
   logger: Logger;
   toolCallConfig: ToolCallConfig;
+  buildRuntimeContext?: (input: {
+    session: SessionSnapshot;
+    context: ActionContext;
+    turnState: TurnState;
+    isFirstIteration: boolean;
+  }) => string;
   emit: (event: RuntimeEvent) => void;
   enqueueTimerTrigger: (trigger: TimerFiredTrigger) => void;
   traceStore: SessionTraceStore;
@@ -52,6 +59,7 @@ export interface ExecuteToolCallInput {
   context: ActionContext;
   turnState: TurnState;
   abortSignal?: AbortSignal;
+  llmIteration?: number;
 }
 
 export class RuntimeToolExecutor {
@@ -60,13 +68,24 @@ export class RuntimeToolExecutor {
   constructor(private readonly options: RuntimeToolExecutorOptions) {}
 
   async execute(input: ExecuteToolCallInput): Promise<string> {
-    const { session, toolCall, context, turnState, abortSignal } = input;
+    const { session, toolCall, context, turnState, abortSignal, llmIteration = 0 } = input;
     const toolDisplayName = this.options.toolRegistry.getDisplayName(toolCall.name);
     const displayToolCall = toolDisplayName
       ? { ...toolCall, displayName: toolDisplayName }
       : toolCall;
 
     throwIfAborted(abortSignal);
+
+    if (toolCall.name === RUNTIME_CONTEXT_TOOL_NAME) {
+      return this.executeRuntimeContext({
+        session,
+        toolCall: displayToolCall,
+        context,
+        turnState,
+        isFirstIteration: llmIteration === 0,
+      });
+    }
+
     this.options.emit({
       type: 'tool-call-proposed',
       sessionId: session.id,
@@ -143,6 +162,43 @@ export class RuntimeToolExecutor {
       command: planResult.plan.command,
       abortSignal,
     });
+  }
+
+  private async executeRuntimeContext(input: {
+    session: SessionSnapshot;
+    toolCall: ToolCall;
+    context: ActionContext;
+    turnState: TurnState;
+    isFirstIteration: boolean;
+  }): Promise<string> {
+    const { session, toolCall, context, turnState, isFirstIteration } = input;
+    const buildRuntimeContext = this.options.buildRuntimeContext;
+    if (!buildRuntimeContext) {
+      return JSON.stringify({
+        error: 'runtime context provider is not configured',
+        _meta: { kind: 'tool-failed', toolName: toolCall.name },
+      });
+    }
+
+    session.deviceState = await this.options.device.getState();
+    const output = buildRuntimeContext({
+      session,
+      context,
+      turnState,
+      isFirstIteration,
+    });
+
+    await this.options.traceStore.append(session.id, {
+      kind: 'tool-result',
+      turnId: context.traceId,
+      sourceType: context.sourceType,
+      toolCallId: toolCall.id,
+      toolName: toolCall.name,
+      toolDisplayName: toolCall.displayName,
+      args: toolCall.args,
+      output,
+    });
+    return output;
   }
 
   private async recordInlineResult(input: {

--- a/packages/runtime/src/runtime-turn-state.ts
+++ b/packages/runtime/src/runtime-turn-state.ts
@@ -1,7 +1,9 @@
-import type { LlmConversationItem } from '@dg-agent/core';
+import type { ConversationMessage, LlmConversationItem } from '@dg-agent/core';
 import type { ModelContextStrategy, SessionSnapshot, ToolCall } from '@dg-agent/core';
 import { REPLY_ABORTED_NOTE, TOOL_LOOP_EXHAUSTED_MESSAGE } from './runtime-errors.js';
+import { hasCompleteToolRound } from './session-history.js';
 import type { ToolCallConfig } from './tool-call-config.js';
+import { RUNTIME_CONTEXT_TOOL_NAME } from './runtime-context-tool.js';
 
 export interface TurnState {
   workingItems: LlmConversationItem[];
@@ -38,18 +40,41 @@ export function buildConversationItems(
   ).filter((message) => shouldIncludePersistedMessage(message, turnState));
 
   return [
-    ...persistedMessages.map<LlmConversationItem>((message) => ({
+    ...persistedMessages.flatMap((message) => persistedMessageToConversationItems(message)),
+    ...(currentInput ? [currentInput] : []),
+    ...turnState.workingItems,
+  ];
+}
+
+function persistedMessageToConversationItems(message: ConversationMessage): LlmConversationItem[] {
+  const includeToolCalls = hasCompleteToolRound(message);
+  const items: LlmConversationItem[] = [
+    {
       kind: 'message',
       role: message.role,
       content: message.content,
       reasoningContent: message.reasoningContent,
-      // toolCalls intentionally omitted: tool results are not persisted to session.messages,
-      // so including tool_calls here would produce an assistant message with tool_calls
-      // but no following tool result messages, causing 400 on strict providers (e.g. DeepSeek).
-    })),
-    ...(currentInput ? [currentInput] : []),
-    ...turnState.workingItems,
+      ...(includeToolCalls ? { toolCalls: message.toolCalls } : {}),
+    },
   ];
+
+  if (!includeToolCalls || !message.toolCalls?.length || !message.toolResults?.length) {
+    return items;
+  }
+
+  for (const toolCall of message.toolCalls) {
+    const result = message.toolResults.find((entry) => entry.callId === toolCall.id);
+    if (!result) {
+      continue;
+    }
+    items.push({
+      kind: 'function_call_output',
+      callId: result.callId,
+      output: result.output,
+    });
+  }
+
+  return items;
 }
 
 export function safeStringify(value: Record<string, unknown>): string {
@@ -88,6 +113,9 @@ export function consumeTurnQuota(
   config: ToolCallConfig,
   toolArgs?: Record<string, unknown>,
 ): string | null {
+  if (toolName === RUNTIME_CONTEXT_TOOL_NAME) {
+    return null;
+  }
   if (turnState.totalToolCalls >= config.maxToolCallsPerTurn) {
     return `本回合工具调用总数已达上限 (${config.maxToolCallsPerTurn})，本次调用被拒绝。请直接回复用户，不要再发起工具调用。`;
   }
@@ -160,7 +188,9 @@ function shouldSkipModelContextMessage(message: SessionSnapshot['messages'][numb
   if (message.role === 'user') return false;
 
   const content = message.content.trim();
-  if (!content) return true;
+  if (!content) {
+    return !(message.role === 'assistant' && hasCompleteToolRound(message));
+  }
 
   if (message.role === 'system') {
     return true;
@@ -200,7 +230,7 @@ function shouldIncludePersistedMessage(
   );
 }
 
-function sameToolCallSequence(left?: ToolCall[], right?: ToolCall[]): boolean {
+export function sameToolCallSequence(left?: ToolCall[], right?: ToolCall[]): boolean {
   const leftCalls = Array.isArray(left) ? left : [];
   const rightCalls = Array.isArray(right) ? right : [];
 

--- a/packages/runtime/src/runtime.test.ts
+++ b/packages/runtime/src/runtime.test.ts
@@ -505,12 +505,28 @@ class TestSessionStore implements SessionStore {
   }
 
   private cloneSession(session: TestSessionStoreEntry): TestSessionStoreEntry {
-    return {
-      ...session,
-      messages: session.messages.map((message) => ({ ...message })),
-      deviceState: { ...session.deviceState },
-      metadata: session.metadata ? structuredClone(session.metadata) : undefined,
-    };
+    return structuredClone(session);
+  }
+}
+
+class JsonRoundtripSessionStore implements SessionStore {
+  private readonly sessions = new Map<string, SessionSnapshot>();
+
+  async get(sessionId: string): Promise<SessionSnapshot | null> {
+    const session = this.sessions.get(sessionId);
+    return session ? structuredClone(session) : null;
+  }
+
+  async save(session: SessionSnapshot): Promise<void> {
+    this.sessions.set(session.id, JSON.parse(JSON.stringify(session)) as SessionSnapshot);
+  }
+
+  async list(): Promise<SessionSnapshot[]> {
+    return Array.from(this.sessions.values()).map((session) => structuredClone(session));
+  }
+
+  async delete(sessionId: string): Promise<void> {
+    this.sessions.delete(sessionId);
   }
 }
 
@@ -1695,5 +1711,138 @@ describe('AgentRuntime', () => {
     });
     const session = await runtime.getSessionSnapshot('legacy-burst');
     expect(session.deviceState.strengthA).toBe(35);
+  });
+
+  it('persists assistant tool rounds with results for later turns', async () => {
+    const llm = new InspectingTwoStepLlm();
+    const runtime = new AgentRuntime({
+      device: new TestDevice(),
+      llm,
+      permission: new TestPermission(),
+      waveformLibrary: createBasicWaveformLibrary(),
+      buildRuntimeContext: () => JSON.stringify({ device: { connection: '未连接' } }),
+    });
+
+    await runtime.sendUserMessage({
+      sessionId: 'tool-history',
+      text: '启动 A',
+      context: { sessionId: 'tool-history', sourceType: 'cli', traceId: 'trace-tool-history' },
+    });
+
+    const session = await runtime.getSessionSnapshot('tool-history');
+    const toolRound = session.messages.find(
+      (message) => message.role === 'assistant' && (message.toolCalls?.length ?? 0) > 0,
+    );
+    expect(toolRound?.toolCalls?.[0]?.name).toBe('start');
+    expect(toolRound?.toolResults).toHaveLength(1);
+    expect(toolRound?.toolResults?.[0]?.output).toContain('"ok"');
+
+    const secondTurnConversation = llm.conversations[1] ?? [];
+    expect(secondTurnConversation.some((item) => item.kind === 'function_call_output')).toBe(true);
+  });
+
+  it('keeps buildInstructions static across tool-loop iterations', async () => {
+    const instructionsLog: string[] = [];
+    const runtime = new AgentRuntime({
+      device: new TestDevice(),
+      llm: new TwoStepLlm(),
+      permission: new TestPermission(),
+      waveformLibrary: createBasicWaveformLibrary(),
+      buildInstructions: () => {
+        const value = 'static-system-prompt';
+        instructionsLog.push(value);
+        return value;
+      },
+      buildRuntimeContext: () => JSON.stringify({ device: { connection: '未连接' } }),
+    });
+
+    await runtime.sendUserMessage({
+      sessionId: 'static-prompt',
+      text: '启动 A',
+      context: { sessionId: 'static-prompt', sourceType: 'cli', traceId: 'trace-static-prompt' },
+    });
+
+    expect(instructionsLog.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(instructionsLog)).toEqual(new Set(['static-system-prompt']));
+  });
+
+  it('executes get_runtime_context without permission prompts', async () => {
+    class ContextToolLlm implements LlmClient {
+      async runTurn() {
+        return {
+          assistantMessage: '让我先看一下状态',
+          toolCalls: [
+            {
+              id: 'ctx-1',
+              name: 'get_runtime_context',
+              args: {},
+            },
+          ],
+        };
+      }
+    }
+
+    const permission = new CountingPermission();
+    const runtime = new AgentRuntime({
+      device: new TestDevice({ connected: true, strengthA: 7, waveActiveA: true }),
+      llm: new ContextToolLlm(),
+      permission,
+      waveformLibrary: createBasicWaveformLibrary(),
+      buildRuntimeContext: () =>
+        JSON.stringify({ device: { channelA: { strength: 7, waveActive: true } } }),
+      toolCallConfig: { maxToolIterations: 2 },
+    });
+
+    await runtime.sendUserMessage({
+      sessionId: 'runtime-context',
+      text: '现在怎么样',
+      context: {
+        sessionId: 'runtime-context',
+        sourceType: 'cli',
+        traceId: 'trace-runtime-context',
+      },
+    });
+
+    expect(permission.callCount).toBe(0);
+    const session = await runtime.getSessionSnapshot('runtime-context');
+    const contextRound = session.messages.find((message) =>
+      message.toolCalls?.some((call) => call.name === 'get_runtime_context'),
+    );
+    expect(contextRound?.toolResults?.[0]?.output).toContain('"strength":7');
+  });
+
+  it('reloads persisted toolResults from session store after runtime restart', async () => {
+    const store = new JsonRoundtripSessionStore();
+    const runtime = new AgentRuntime({
+      device: new TestDevice(),
+      llm: new TwoStepLlm(),
+      permission: new TestPermission(),
+      waveformLibrary: createBasicWaveformLibrary(),
+      sessionStore: store,
+      buildRuntimeContext: () => JSON.stringify({ device: { connection: '未连接' } }),
+    });
+
+    await runtime.sendUserMessage({
+      sessionId: 'reload-tool-history',
+      text: '启动 A',
+      context: {
+        sessionId: 'reload-tool-history',
+        sourceType: 'cli',
+        traceId: 'trace-reload-tool-history',
+      },
+    });
+
+    const reloaded = new AgentRuntime({
+      device: new TestDevice(),
+      llm: new TwoStepLlm(),
+      permission: new TestPermission(),
+      waveformLibrary: createBasicWaveformLibrary(),
+      sessionStore: store,
+    });
+    const session = await reloaded.getSessionSnapshot('reload-tool-history');
+    const toolRound = session.messages.find(
+      (message) => message.role === 'assistant' && (message.toolCalls?.length ?? 0) > 0,
+    );
+    expect(toolRound?.toolResults).toHaveLength(1);
   });
 });

--- a/packages/runtime/src/session-history.test.ts
+++ b/packages/runtime/src/session-history.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { createEmptyDeviceState, type SessionSnapshot } from '@dg-agent/core';
+import { hydrateToolResultsFromTrace, normalizeSessionHistory } from './session-history.js';
+
+describe('session-history', () => {
+  it('hydrates missing toolResults from trace entries', () => {
+    const session: SessionSnapshot = {
+      id: 's1',
+      createdAt: 0,
+      updatedAt: 0,
+      deviceState: createEmptyDeviceState(),
+      messages: [
+        {
+          id: 'a1',
+          role: 'assistant',
+          content: '',
+          createdAt: 1,
+          toolCalls: [{ id: 'call-1', name: 'stop', args: { channel: 'A' } }],
+        },
+      ],
+    };
+
+    const changed = hydrateToolResultsFromTrace(session, [
+      {
+        id: 'trace-1',
+        createdAt: 1,
+        kind: 'tool-result',
+        toolCallId: 'call-1',
+        toolName: 'stop',
+        output: '{"ok":true}',
+      },
+    ]);
+
+    expect(changed).toBe(true);
+    expect(session.messages[0]?.toolResults?.[0]?.output).toBe('{"ok":true}');
+  });
+
+  it('keeps assistant messages with complete tool rounds during normalize', () => {
+    const session: SessionSnapshot = {
+      id: 's1',
+      createdAt: 0,
+      updatedAt: 0,
+      deviceState: createEmptyDeviceState(),
+      messages: [
+        {
+          id: 'a1',
+          role: 'assistant',
+          content: '',
+          createdAt: 1,
+          toolCalls: [{ id: 'call-1', name: 'stop', args: { channel: 'A' } }],
+        },
+        {
+          id: 'a2',
+          role: 'assistant',
+          content: '',
+          createdAt: 2,
+          toolCalls: [{ id: 'call-1', name: 'stop', args: { channel: 'A' } }],
+          toolResults: [{ callId: 'call-1', output: '{"ok":true}' }],
+        },
+      ],
+    };
+
+    expect(normalizeSessionHistory(session)).toBe(true);
+    expect(session.messages).toHaveLength(1);
+    expect(session.messages[0]?.toolResults?.[0]?.output).toBe('{"ok":true}');
+  });
+});

--- a/packages/runtime/src/session-history.ts
+++ b/packages/runtime/src/session-history.ts
@@ -2,8 +2,10 @@ import type { LlmConversationItem } from '@dg-agent/core';
 import {
   createMessage,
   type ConversationMessage,
+  type RuntimeTraceEntry,
   type SessionSnapshot,
   type ToolCall,
+  type ToolCallResult,
 } from '@dg-agent/core';
 
 export function normalizeSessionHistory(session: SessionSnapshot): boolean {
@@ -22,6 +24,12 @@ export function normalizeSessionHistory(session: SessionSnapshot): boolean {
         previousComparable?.role === 'assistant' &&
         areAssistantMessagesEquivalent(previousComparable, message)
       ) {
+        if (hasCompleteToolRound(message) && !hasCompleteToolRound(previousComparable)) {
+          const index = normalizedMessages.lastIndexOf(previousComparable);
+          if (index >= 0) {
+            normalizedMessages[index] = message;
+          }
+        }
         changed = true;
         continue;
       }
@@ -49,6 +57,73 @@ function findPreviousComparableMessage(
   }
 
   return undefined;
+}
+
+export function hasCompleteToolRound(message: ConversationMessage): boolean {
+  const toolCalls = message.toolCalls ?? [];
+  const toolResults = message.toolResults ?? [];
+  if (toolCalls.length === 0 || toolResults.length !== toolCalls.length) {
+    return false;
+  }
+
+  return toolCalls.every((toolCall) => toolResults.some((result) => result.callId === toolCall.id));
+}
+
+export function hydrateToolResultsFromTrace(
+  session: SessionSnapshot,
+  trace: RuntimeTraceEntry[],
+): boolean {
+  let changed = false;
+
+  for (const message of session.messages) {
+    if (message.role !== 'assistant' || !message.toolCalls?.length) {
+      continue;
+    }
+    if (hasCompleteToolRound(message)) {
+      continue;
+    }
+
+    const toolResults = message.toolCalls.flatMap((toolCall) => {
+      const output = resolveTraceToolOutput(trace, toolCall.id);
+      return output ? [{ callId: toolCall.id, output }] : [];
+    });
+
+    if (toolResults.length !== message.toolCalls.length) {
+      continue;
+    }
+
+    message.toolResults = toolResults;
+    changed = true;
+  }
+
+  return changed;
+}
+
+export function appendAssistantToolRound(
+  session: SessionSnapshot,
+  input: {
+    content: string;
+    reasoningContent?: string;
+    toolCalls: ToolCall[];
+    toolResults: ToolCallResult[];
+  },
+  turnStartIndex: number,
+): ConversationMessage {
+  const message = appendAssistantMessage(
+    session,
+    {
+      content: input.content,
+      reasoningContent: input.reasoningContent,
+      toolCalls: input.toolCalls.length > 0 ? input.toolCalls : undefined,
+    },
+    turnStartIndex,
+  );
+  if (input.toolCalls.length > 0) {
+    message.toolCalls = structuredClone(input.toolCalls);
+  }
+  message.toolResults =
+    input.toolResults.length > 0 ? structuredClone(input.toolResults) : undefined;
+  return message;
 }
 
 export function appendAssistantMessage(
@@ -107,11 +182,27 @@ export function buildAssistantMessageSignature(input: {
 }): string {
   // Dedup by visible text and reasoning only. Tool calls are intentionally
   // excluded so an iteration that emitted "X" with a tool call dedupes against
-  // a later final reply that emits "X" without tool calls.
+  // a later final reply that emits "X" without tool calls — unless the message
+  // is tool-only (empty visible text), in which case tool calls identify it.
+  const toolSignature =
+    input.content.trim().length === 0 && input.toolCalls?.length
+      ? input.toolCalls
+          .map((toolCall) => `${toolCall.id}:${toolCall.name}:${safeStringify(toolCall.args)}`)
+          .join('|')
+      : '';
   return JSON.stringify({
     content: input.content.trim(),
     reasoningContent: input.reasoningContent?.trim() ?? '',
+    toolSignature,
   });
+}
+
+function safeStringify(value: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '{}';
+  }
 }
 
 export function appendSkippedToolOutputs(
@@ -140,4 +231,39 @@ function isInternalSyntheticMessage(content: string): boolean {
     content.startsWith('[内部提醒]') ||
     content.startsWith('[系统事件：定时器到期]')
   );
+}
+
+function resolveTraceToolOutput(trace: RuntimeTraceEntry[], callId: string): string | null {
+  for (let index = trace.length - 1; index >= 0; index -= 1) {
+    const entry = trace[index];
+    if (!entry || entry.toolCallId !== callId) {
+      continue;
+    }
+
+    if (entry.kind === 'tool-result' && entry.output) {
+      return entry.output;
+    }
+
+    if (entry.kind === 'tool-denied') {
+      return JSON.stringify({
+        error: entry.detail ?? 'denied',
+        _meta: {
+          kind: 'tool-denied',
+          toolName: entry.toolName,
+        },
+      });
+    }
+
+    if (entry.kind === 'tool-failed') {
+      return JSON.stringify({
+        error: entry.detail ?? 'failed',
+        _meta: {
+          kind: 'tool-failed',
+          toolName: entry.toolName,
+        },
+      });
+    }
+  }
+
+  return null;
 }


### PR DESCRIPTION
## 概述

**System Prompt 静态化：** 原先每轮都会在 system prompt 里拼接设备状态、本回合工具清单、迭代策略等动态内容，导致前缀每轮变化，无法命中 Prompt Caching。现将 system prompt 固定为场景 preset、设备说明与行为规则等稳定内容；动态信息改由 `get_runtime_context` 工具按需返回。

**Tool Result 落盘：** 此前 tool 执行结果只存在于当轮内存，未写入会话历史；刷新或进入下一轮后，agent 无法得知上一轮调了什么、返回了什么，容易重复调用或编造结果。现将每轮 `toolCalls` + `toolResults` 一并持久化，加载时从 IndexedDB 读取，缺失时从 trace 回填，保证多轮对话中 tool 调用链完整。

**其他：** 修复工具落盘后 `session-updated` 更频繁触发，导致 live trace 与历史 trace 短暂重叠、聊天区「已执行」重复显示的问题。

## 测试计划

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test`
- [ ] `npm run build`
- [ ] 浏览器烟测：调工具 → 硬刷新 → 再发消息，确认模型仍能利用历史 tool result；确认「已执行」条目不重复

## 影响范围

- **非 breaking**：`ConversationMessage` 新增可选字段 `toolResults`；旧会话无此字段时，加载时尝试从 trace 回填
- 新增工具 `get_runtime_context`（inline，不走 Permission，不计入 tool 配额）
- `buildInstructions` 签名简化为 `(input: { context }) => string`，仅 `agent-browser` 侧调用

## 关联

无