### PR TITLE
feat(providers): default all providers to Chat endpoint + non-strict schema

### DIFF
--- a/packages/providers-catalog/src/index.test.ts
+++ b/packages/providers-catalog/src/index.test.ts
@@ -21,7 +21,7 @@ describe('providers-catalog', () => {
     expect(normalized.baseUrl).toBe('https://api.openai.com/v1');
     expect(normalized.model).toBe('gpt-4o-mini');
     expect(normalized.endpoint).toBe('chat/completions');
-    expect(normalized.useStrict).toBe(true);
+    expect(normalized.useStrict).toBe(false);
   });
 
   it('maps the free provider to the browser proxy runtime settings', () => {
@@ -44,6 +44,24 @@ describe('providers-catalog', () => {
     expect(normalized.model).toBe('deepseek-v4-pro');
     expect(normalized.baseUrl).toBe('https://api.deepseek.com');
     expect(normalized.endpoint).toBe('chat/completions');
+  });
+
+  it('defaults the custom provider to the Chat endpoint with strict schema off', () => {
+    const normalized = createProviderSettings('custom');
+
+    expect(normalized.endpoint).toBe('chat/completions');
+    expect(normalized.useStrict).toBe(false);
+  });
+
+  it('keeps the custom strict toggle user-editable across normalization', () => {
+    const normalized = normalizeProviderSettings({
+      ...createProviderSettings('custom'),
+      useStrict: true,
+      endpoint: 'responses',
+    });
+
+    expect(normalized.useStrict).toBe(true);
+    expect(normalized.endpoint).toBe('responses');
   });
 
   it('detects whether a provider needs a user API key', () => {

--- a/packages/providers-catalog/src/index.ts
+++ b/packages/providers-catalog/src/index.ts
@@ -40,12 +40,16 @@ const PROVIDER_IDS = [
   'openai',
   'custom',
 ] as const satisfies ProviderId[];
+// These seed every freshly created provider config. For built-in providers
+// `normalizeProviderSettings` overrides `endpoint`/`useStrict` below, so these
+// values only survive for the user-editable `custom` provider — hence the
+// Chat-Completions + non-strict defaults requested for custom backends.
 const BASE_PROVIDER_SETTINGS = {
   apiKey: '',
   model: '',
   baseUrl: '',
-  endpoint: 'responses' as const,
-  useStrict: true,
+  endpoint: 'chat/completions' as const,
+  useStrict: false,
 };
 
 const providerSettingsSchema = z.object({
@@ -173,30 +177,33 @@ export function normalizeProviderSettings(input: ProviderSettings): ProviderSett
         normalized.baseUrl || 'https://dashscope.aliyuncs.com/compatible-mode/v1';
       normalized.model = normalized.model || 'qwen3.5-plus';
       normalized.endpoint = 'chat/completions';
-      normalized.useStrict = true;
+      normalized.useStrict = false;
       break;
     case 'deepseek':
       normalized.baseUrl = normalized.baseUrl || 'https://api.deepseek.com';
       normalized.model = normalized.model || 'deepseek-v4-pro';
       normalized.endpoint = 'chat/completions';
-      normalized.useStrict = true;
+      normalized.useStrict = false;
       break;
     case 'doubao':
       normalized.baseUrl = normalized.baseUrl || 'https://ark.cn-beijing.volces.com/api/v3';
       normalized.model = normalized.model || 'doubao-seed-2-0-mini-250415';
-      normalized.endpoint = 'responses';
-      normalized.useStrict = true;
+      normalized.endpoint = 'chat/completions';
+      normalized.useStrict = false;
       break;
     case 'openai':
       normalized.baseUrl = normalized.baseUrl || 'https://api.openai.com/v1';
       normalized.model = normalized.model || 'gpt-4o-mini';
       normalized.endpoint = 'chat/completions';
-      normalized.useStrict = true;
+      normalized.useStrict = false;
       break;
     case 'custom':
+      // endpoint/useStrict stay user-editable: only fill the endpoint when it's
+      // missing (seeded to chat/completions via BASE_PROVIDER_SETTINGS) and never
+      // clobber the user's strict toggle.
       normalized.baseUrl = normalized.baseUrl || 'https://api.example.com/v1';
       normalized.model = normalized.model || 'model-name';
-      normalized.endpoint = normalized.endpoint || 'responses';
+      normalized.endpoint = normalized.endpoint || 'chat/completions';
       break;
     case 'free':
       normalized.baseUrl = FREE_TRIAL_PROXY_URL + '/v1';

--- a/packages/providers-openai-http/src/index.ts
+++ b/packages/providers-openai-http/src/index.ts
@@ -20,7 +20,7 @@ const configSchema = z.object({
   model: z.string().min(1),
   temperature: z.number().min(0).max(2).default(0.3),
   endpoint: z.enum(['responses', 'chat/completions']).default('chat/completions'),
-  useStrict: z.boolean().default(true),
+  useStrict: z.boolean().default(false),
   extraHeaders: z
     .custom<() => Record<string, string> | Promise<Record<string, string>>>()
     .optional(),

--- a/packages/storage-browser/src/browser-settings-defaults.ts
+++ b/packages/storage-browser/src/browser-settings-defaults.ts
@@ -47,7 +47,7 @@ export function defaultBrowserAppSettings(env: BrowserAppEnvLike = {}): BrowserA
     baseUrl: env.VITE_OPENAI_BASE_URL ?? '',
     model: env.VITE_OPENAI_MODEL ?? '',
     endpoint: 'chat/completions',
-    useStrict: true,
+    useStrict: false,
   });
 
   return {


### PR DESCRIPTION
## Summary
Switch the default tool-call interface for **every** provider (qwen / deepseek / doubao / openai / custom) to **Chat Completions** with **strict JSON schema off**. The `custom` provider keeps both the 接口类型 and 严格 Schema selectors user-editable — only its seeded default changed. Already-saved provider configs are untouched (defaults only affect newly created / reset configs).

### Changes
- `providers-catalog`: `BASE_PROVIDER_SETTINGS` seeds custom with `chat/completions` + `useStrict: false`; qwen/deepseek/doubao/openai now force non-strict; doubao endpoint `responses` → `chat/completions`; custom endpoint fallback → `chat/completions`.
- `providers-openai-http`: config-schema `useStrict` default `true` → `false`.
- `storage-browser`: initial provider seed `useStrict` → `false`.
- Tests: updated openai default assertion; added custom default + user-toggle-preserved cases.

## Test plan
- [x] npm run typecheck
- [x] npm run test (94 passed)
- [x] npm run lint (0 warnings)
- [x] npm run build